### PR TITLE
Add bower.json for bower publishing

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,13 @@
+{
+  "name": "scales",
+  "version": "1.0.0",
+  "main": "style.scss",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "LICENSE.md",
+    "README.md",
+    "index.html",
+    "config.rb"
+  ]
+}


### PR DESCRIPTION
This adds version and name info to the bower repo.

Caveats:
- removes config.rb when installed with bower (this should be handled per
  project using it, not all build systems use config.rb [ie grunt])
- we need to version this beast!
