### PR TITLE
Add intrinsic-ratio pattern

### DIFF
--- a/scales/_scales.scss
+++ b/scales/_scales.scss
@@ -82,6 +82,7 @@
     @import "patterns/link-complex";
     @import "patterns/buttons";
     @import "patterns/stats";
+    @import "patterns/intrinsic-ratio";
 
 
 /*

--- a/scales/patterns/_intrinsic-ratio.scss
+++ b/scales/patterns/_intrinsic-ratio.scss
@@ -1,0 +1,26 @@
+/* ==========================================================================
+Intrinsic Ratio
+========================================================================== */
+
+/*
+ * Content with a specific ratio, often video or other media
+ *
+     <div class="ratio-wrapper">
+        <iframe class="ratio-preserve" src="video.html"></iframe>
+     </div>
+ *
+ */
+[class*=ratio-wrapper] {
+    position: relative;
+    height: 0;
+    padding-bottom: 56.25%; /* 16:9 */
+
+    > [class*=ratio-preserve] {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+    }
+
+}


### PR DESCRIPTION
This pattern allows you to preserve the aspect ratio of video using padding. It
requires that you know the ratio of your video (16:9 is provided by default). See [CSS Tricks](http://css-tricks.com/NetMag/FluidWidthVideo/Article-FluidWidthVideo.php) for this technique.