### PR TITLE
Remove Media Queries

### DIFF
--- a/_vars.scss
+++ b/_vars.scss
@@ -66,26 +66,6 @@ $ratio: fourth();
 ///
 @include establish-baseline;
 
-
-//
-// Responsive design breakpoints
-//
-// Scales is a mobile-first framework, so it needs to know when you want
-// to begin applying "non-mobile" styles to the design patterns.
-//
-// It is not advisable to set breakpoints in responsive designs based on specific
-// device widths. Instead, breakpoints should be applied when your content begins
-// to look awkward. If there are other widths that you need to specifically support
-// and a named variable makes sense, feel free to add it here (ex. $desk-start: 64.0625em; // 1025px ).
-//
-// Using ems instead of px allows your breakpoints to be relative to your $base-font-size.
-//
-// Usage:
-// @media screen and (min-width: $palm-end) { [Styles Here] }
-///
-$palm-end: 30.0625em !default; // 481px
-
-
 //
 // Heading sizes.
 ///

--- a/scales/base/_tables.scss
+++ b/scales/base/_tables.scss
@@ -64,10 +64,6 @@ th,
 td {
     padding: 0 msem(-3);
     @include rhythm(0,.25,.25,0, ms(0));
-    @media screen and (min-width: $palm-end) {
-        padding: 0 msem(-1);
-        @include rhythm(0,.5,.5,0);
-    }
     text-align:left;
 }
 

--- a/scales/patterns/_nav.scss
+++ b/scales/patterns/_nav.scss
@@ -68,41 +68,38 @@
 
 
 //
-// Nav abstractions on screens larger than $palm-end.
+// Makes the .nav horizontal
+// usage:
+//
+//  <ul class="horizontal-nav">
 ///
-@media screen and (min-width: $palm-end) {
-    //
-    // Makes the .nav horizontal
-    ///
-    [class*="nav"] {
-        > li {
-
-            &,
-            > a {
-                display: inline-block;
-            }
-        }
-    }
+.horizontal-nav {
+	> li {
+		&, > a {
+			display: inline-block;
+		}
+	}
+}
 
 
-    //
-    // Force nav to occupy 100% of the available width of its parent. Extends .nav.
-    //
-    // usage:
-    //
-    //  <ul class="nav--fit>
-    //
-    ///
-    .nav--fit {
-        display: table;
-        width: 100%;
+//
+// Force nav to occupy 100% of the available width of its parent. Extends .nav.
+//
+// usage:
+//
+//  <ul class="horizontal-nav--fit">
+//
+///
+.nav--fit {
+	@extend .horizontal-nav
+	display: table;
+	width: 100%;
 
-        > li {
-            display: table-cell;
+	> li {
+			display: table-cell;
 
-            > a {
-                display: block;
-            }
-        }
-    }
+		> a {
+			display: block;
+		}
+	}
 }


### PR DESCRIPTION
Media queries should be determined by your content, therefore, we should not
dictate them. This not only gives the developer more freedom, but also gives us
a more expansive library of patterns, as some may work in both contexts.

I modified the nav pattern to create two derivatives that are based on the wide
viewport nav implmentation: .horizontal-nav and .horizontal-nav--fit. Change
the naming as you see fit.