### PR TITLE
change Flag to use Flexbox instead of tables

### DIFF
--- a/packages/objects-flag/_flag.scss
+++ b/packages/objects-flag/_flag.scss
@@ -32,14 +32,12 @@ $flag-stacked-breakpoint: 25em !default;
 // Flag classes
 ///
 .#{$scales-namespace}#{$scales-objects-class-namespace}Flag {
-  display: table;
-  width: 100%;
+  display: flex;
 }
 
 .#{$scales-namespace}#{$scales-objects-class-namespace}Flag__body,
 .#{$scales-namespace}#{$scales-objects-class-namespace}Flag__figure {
-  display: table-cell;
-  vertical-align: top;
+  flex: 1 1 auto;
 }
 
 .#{$scales-namespace}#{$scales-objects-class-namespace}Flag__figure {
@@ -52,7 +50,6 @@ $flag-stacked-breakpoint: 25em !default;
 }
 
 .#{$scales-namespace}#{$scales-objects-class-namespace}Flag__body {
-  width: 100%;
 
   > :last-child,
   & {
@@ -64,12 +61,7 @@ $flag-stacked-breakpoint: 25em !default;
 // Reversed flag
 ///
 .#{$scales-namespace}#{$scales-objects-class-namespace}Flag--rev {
-  direction: rtl;
-
-  > .#{$scales-namespace}#{$scales-objects-class-namespace}Flag__body,
-  > .#{$scales-namespace}#{$scales-objects-class-namespace}Flag__figure {
-    direction: ltr;
-  }
+  flex-direction: row-reverse;
 
   > .#{$scales-namespace}#{$scales-objects-class-namespace}Flag__figure {
     padding-right: 0;
@@ -157,7 +149,7 @@ $flag-stacked-breakpoint: 25em !default;
 .#{$scales-namespace}#{$scales-objects-class-namespace}Flag--middle {
   > .#{$scales-namespace}#{$scales-objects-class-namespace}Flag__body,
   > .#{$scales-namespace}#{$scales-objects-class-namespace}Flag__figure {
-    vertical-align: middle;
+    justify-self: center;
   }
 }
 
@@ -167,7 +159,7 @@ $flag-stacked-breakpoint: 25em !default;
 .#{$scales-namespace}#{$scales-objects-class-namespace}Flag--bottom {
   > .#{$scales-namespace}#{$scales-objects-class-namespace}Flag__body,
   > .#{$scales-namespace}#{$scales-objects-class-namespace}Flag__figure {
-    vertical-align: bottom;
+    justify-self: flex-end;
   }
 }
 
@@ -180,7 +172,6 @@ $flag-stacked-breakpoint: 25em !default;
   // Default stacked flag
   ///
   .#{$scales-namespace}#{$scales-objects-class-namespace}Flag--stacked {
-    direction: ltr;
 
     > .#{$scales-namespace}#{$scales-objects-class-namespace}Flag__body,
     > .#{$scales-namespace}#{$scales-objects-class-namespace}Flag__figure,

--- a/packages/objects-flag/index.html
+++ b/packages/objects-flag/index.html
@@ -6,14 +6,12 @@
 <meta name="viewport" content="initial-scale=1,width=device-width">
 <style>
 .Flag {
-  display: table;
-  width: 100%;
+  display: flex;
 }
 
 .Flag__body,
 .Flag__figure {
-  display: table-cell;
-  vertical-align: top;
+  flex: 1 1 auto;
 }
 
 .Flag__figure {
@@ -32,12 +30,9 @@
 }
 
 .Flag--rev {
-  direction: rtl;
+  flex-direction: row-reverse;
 }
-.Flag--rev > .Flag__body,
-.Flag--rev > .Flag__figure {
-  direction: ltr;
-}
+
 .Flag--rev > .Flag__figure {
   padding-right: 0;
   padding-left: 1em;
@@ -82,18 +77,16 @@
 
 .Flag--middle > .Flag__body,
 .Flag--middle > .Flag__figure {
-  vertical-align: middle;
+  align-self: center;
 }
 
 .Flag--bottom > .Flag__body,
 .Flag--bottom > .Flag__figure {
-  vertical-align: bottom;
+  align-self: flex-end;
 }
 
 @media all and (max-width: 25em) {
-  .Flag--stacked {
-    direction: ltr;
-  }
+  
   .Flag--stacked > .Flag__body,
   .Flag--stacked > .Flag__figure, .Flag--stacked {
     display: block;


### PR DESCRIPTION
I was unable to run stylelint-scss before I pushed the changes to my feature branch. 

Changes: 
- changed `display:table` to `display:flex`
- removed `direction: rtl` for `--rev`
- removed `direction: ltr` for `--stacked`